### PR TITLE
Change the name of Data Explorer View

### DIFF
--- a/ckanext/dataexplorer/plugin.py
+++ b/ckanext/dataexplorer/plugin.py
@@ -170,7 +170,7 @@ class DataExplorerView(DataExplorerViewBase):
 
     def info(self):
         return {'name': 'dataexplorer_view',
-                'title': 'Data Explorer',
+                'title': 'Data Explorer Custom',
                 'icon': 'table',
                 'requires_datastore': True,
                 'default_title': p.toolkit._('Data Explorer'),


### PR DESCRIPTION
Change the name of the Data Explorer View so it can be different compared to the default Data Explorer View from CKAN.